### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   <img src="https://img.shields.io/badge/python-3.10%2B-blue?logo=python&logoColor=white" alt="Python"/>
   <img src="https://img.shields.io/badge/LangGraph-1.0%2B-orange?logo=langchain&logoColor=white" alt="LangGraph"/>
   <img src="https://img.shields.io/badge/Qdrant-vector%20db-DC244C" alt="Qdrant"/>
-  <img src="https://img.shields.io/badge/LLM%20Providers-Ollama%20%7C%20OpenAI%20%7C%20Anthropic%20%7C%20Google-purple" alt="LLM Providers"/>
+  <img src="https://img.shields.io/badge/LLM%20Providers-Ollama%20%7C%20OpenAI%20%7C%20Anthropic%20%7C%20Google%20%7C%20MiniMax-purple" alt="LLM Providers"/>
 </p>
 
 <p align="center">
@@ -171,6 +171,25 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 os.environ["GOOGLE_API_KEY"] = "your-api-key-here"
 llm = ChatGoogleGenerativeAI(model="gemini-2.5-flash", temperature=0)
 ```
+
+**MiniMax**
+```bash
+pip install -qU langchain-openai
+```
+```python
+from langchain_openai import ChatOpenAI
+import os
+
+os.environ["MINIMAX_API_KEY"] = "your-api-key-here"
+llm = ChatOpenAI(
+    model="MiniMax-M2.5",
+    base_url="https://api.minimax.io/v1",
+    api_key=os.environ["MINIMAX_API_KEY"],
+    temperature=1.0,
+)
+```
+> Available models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed` (faster). Both support 204,800 token context. See [API docs](https://platform.minimax.io/docs/api-reference/text-openai-api).
+
 </details>
 
 ---

--- a/project/README.md
+++ b/project/README.md
@@ -219,6 +219,7 @@ pip install langchain-openai langchain-anthropic langchain-google-genai
 export OPENAI_API_KEY="your-openai-key"
 export ANTHROPIC_API_KEY="your-anthropic-key"
 export GOOGLE_API_KEY="your-google-key"
+export MINIMAX_API_KEY="your-minimax-key"
 ```
 
 **Step 3:** Update `project/config.py` with multi-provider configuration
@@ -242,6 +243,11 @@ LLM_CONFIGS = {
     "google": {
         "model": "gemini-2.5-flash",
         "temperature": 0
+    },
+    "minimax": {
+        "model": "MiniMax-M2.5",
+        "base_url": "https://api.minimax.io/v1",
+        "temperature": 1.0
     }
 }
 
@@ -249,43 +255,7 @@ LLM_CONFIGS = {
 ACTIVE_LLM_CONFIG = "ollama"
 ```
 
-**Step 4:** Modify `project/core/rag_system.py` in the `initialize()` method
-
-Replace the existing LLM initialization with:
-
-```python
-def initialize(self):
-    self.vector_db.create_collection(self.collection_name)
-    collection = self.vector_db.get_collection(self.collection_name)
-    
-    # Load active configuration
-    active_config = config.LLM_CONFIGS[config.ACTIVE_LLM_CONFIG]
-    model = active_config["model"]
-    temperature = active_config["temperature"]
-    
-    if config.ACTIVE_LLM_CONFIG == "ollama":
-        from langchain_ollama import ChatOllama
-        llm = ChatOllama(model=model, temperature=temperature, base_url=active_config["url"])
-        
-    elif config.ACTIVE_LLM_CONFIG == "openai":
-        from langchain_openai import ChatOpenAI
-        llm = ChatOpenAI(model=model, temperature=temperature)
-        
-    elif config.ACTIVE_LLM_CONFIG == "anthropic":
-        from langchain_anthropic import ChatAnthropic
-        llm = ChatAnthropic(model=model, temperature=temperature)
-        
-    elif config.ACTIVE_LLM_CONFIG == "google":
-        from langchain_google_genai import ChatGoogleGenerativeAI
-        llm = ChatGoogleGenerativeAI(model=model, temperature=temperature)
-        
-    else:
-        raise ValueError(f"Unsupported LLM provider: {config.ACTIVE_LLM_CONFIG}")
-    
-    # Continue with tool and graph initialization
-    tools = ToolFactory(collection).create_tools()
-    self.agent_graph = create_agent_graph(llm, tools)
-```
+> **Note:** Multi-provider support is already implemented in the codebase. Simply update `ACTIVE_LLM_CONFIG` in `config.py` to switch providers.
 
 **Switching Providers:** Simply change `ACTIVE_LLM_CONFIG` in `config.py`:
 
@@ -293,6 +263,7 @@ def initialize(self):
 ACTIVE_LLM_CONFIG = "google"  # Switch to Gemini Pro
 # ACTIVE_LLM_CONFIG = "anthropic"  # Or Claude Sonnet
 # ACTIVE_LLM_CONFIG = "openai"  # Or GPT-4o
+# ACTIVE_LLM_CONFIG = "minimax"  # Or MiniMax M2.5
 ```
 
 ---
@@ -301,9 +272,10 @@ ACTIVE_LLM_CONFIG = "google"  # Switch to Gemini Pro
 
 | Provider | Environment Variable | Import Statement | Example Models |
 |----------|---------------------|------------------|----------------|
-| OpenAI | `OPENAI_API_KEY` | `from langchain_openai import ChatOpenAI` | `gpt-5.2`, `ggpt-5-mini` |
+| OpenAI | `OPENAI_API_KEY` | `from langchain_openai import ChatOpenAI` | `gpt-5.2`, `gpt-5-mini` |
 | Anthropic | `ANTHROPIC_API_KEY` | `from langchain_anthropic import ChatAnthropic` | `claude-opus-4-6`, `claude-sonnet-4-6` |
 | Google | `GOOGLE_API_KEY` | `from langchain_google_genai import ChatGoogleGenerativeAI` | `gemini-2.5-pro`, `gemini-2.5-flash` |
+| MiniMax | `MINIMAX_API_KEY` | `from langchain_openai import ChatOpenAI` | `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` |
 | Ollama | None (local) | `from langchain_ollama import ChatOllama` | `qwen3:4b-instruct-2507-q4_K_M`, `ministral-3:8b-instruct-2512-q4_K_M`, `llama3.1:8b-instruct-q6_K` |
 
 ---

--- a/project/config.py
+++ b/project/config.py
@@ -14,8 +14,39 @@ SPARSE_VECTOR_NAME = "sparse"
 # --- Model Configuration ---
 DENSE_MODEL = "sentence-transformers/all-mpnet-base-v2"
 SPARSE_MODEL = "Qdrant/bm25"
-LLM_MODEL = "qwen3:4b-instruct-2507-q4_K_M"
-LLM_TEMPERATURE = 0
+
+# --- Multi-Provider LLM Configuration ---
+LLM_CONFIGS = {
+    "ollama": {
+        "model": "qwen3:4b-instruct-2507-q4_K_M",
+        "url": "http://localhost:11434",
+        "temperature": 0
+    },
+    "openai": {
+        "model": "gpt-4o-mini",
+        "temperature": 0
+    },
+    "anthropic": {
+        "model": "claude-sonnet-4-5-20250929",
+        "temperature": 0
+    },
+    "google": {
+        "model": "gemini-2.5-flash",
+        "temperature": 0
+    },
+    "minimax": {
+        "model": "MiniMax-M2.5",
+        "base_url": "https://api.minimax.io/v1",
+        "temperature": 1.0
+    }
+}
+
+# Switch providers by changing this single line
+ACTIVE_LLM_CONFIG = "ollama"
+
+# Legacy single-provider config (kept for backward compatibility)
+LLM_MODEL = LLM_CONFIGS[ACTIVE_LLM_CONFIG]["model"]
+LLM_TEMPERATURE = LLM_CONFIGS[ACTIVE_LLM_CONFIG]["temperature"]
 
 # --- Agent Configuration ---
 MAX_TOOL_CALLS = 8

--- a/project/core/rag_system.py
+++ b/project/core/rag_system.py
@@ -1,5 +1,5 @@
+import os
 import uuid
-from langchain_ollama import ChatOllama
 import config
 from db.vector_db_manager import VectorDbManager
 from db.parent_store_manager import ParentStoreManager
@@ -7,8 +7,44 @@ from document_chunker import DocumentChuncker
 from rag_agent.tools import ToolFactory
 from rag_agent.graph import create_agent_graph
 
+
+def _create_llm():
+    """Create an LLM instance based on the active provider configuration."""
+    active_config = config.LLM_CONFIGS[config.ACTIVE_LLM_CONFIG]
+    model = active_config["model"]
+    temperature = active_config["temperature"]
+
+    if config.ACTIVE_LLM_CONFIG == "ollama":
+        from langchain_ollama import ChatOllama
+        return ChatOllama(model=model, temperature=temperature, base_url=active_config.get("url"))
+
+    elif config.ACTIVE_LLM_CONFIG == "openai":
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(model=model, temperature=temperature)
+
+    elif config.ACTIVE_LLM_CONFIG == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(model=model, temperature=temperature)
+
+    elif config.ACTIVE_LLM_CONFIG == "google":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        return ChatGoogleGenerativeAI(model=model, temperature=temperature)
+
+    elif config.ACTIVE_LLM_CONFIG == "minimax":
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=model,
+            temperature=temperature,
+            base_url=active_config.get("base_url", "https://api.minimax.io/v1"),
+            api_key=os.environ.get("MINIMAX_API_KEY"),
+        )
+
+    else:
+        raise ValueError(f"Unsupported LLM provider: {config.ACTIVE_LLM_CONFIG}")
+
+
 class RAGSystem:
-    
+
     def __init__(self, collection_name=config.CHILD_COLLECTION):
         self.collection_name = collection_name
         self.vector_db = VectorDbManager()
@@ -17,12 +53,12 @@ class RAGSystem:
         self.agent_graph = None
         self.thread_id = str(uuid.uuid4())
         self.recursion_limit = 50
-        
+
     def initialize(self):
         self.vector_db.create_collection(self.collection_name)
         collection = self.vector_db.get_collection(self.collection_name)
-        
-        llm = ChatOllama(model=config.LLM_MODEL, temperature=config.LLM_TEMPERATURE)
+
+        llm = _create_llm()
         tools = ToolFactory(collection).create_tools()
         self.agent_graph = create_agent_graph(llm, tools)
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ langchain==1.2.3
 langchain-core==1.2.7
 langchain-huggingface==1.2.0
 langchain-ollama==1.0.1
+langchain-openai>=0.3.0
 langchain-qdrant==1.1.0
 langchain-text-splitters==1.1.0
 langgraph==1.0.5

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,141 @@
+"""Unit tests for multi-provider LLM configuration."""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Add project directory to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "project"))
+
+# Mock ALL heavy dependencies before importing anything from the project.
+# This avoids the need to install the full dependency tree for unit testing.
+_MOCK_MODULES = [
+    "langchain_huggingface", "langchain_qdrant", "langchain_qdrant.fastembed_sparse",
+    "langchain_qdrant.qdrant", "qdrant_client", "qdrant_client.http",
+    "qdrant_client.http.models", "langchain_ollama", "langchain_openai",
+    "langchain_text_splitters", "langchain.text_splitter", "gradio",
+    "pymupdf", "pymupdf.layout", "pymupdf4llm",
+    "langgraph", "langgraph.graph", "langgraph.checkpoint",
+    "langgraph.checkpoint.memory", "langgraph.prebuilt", "langgraph.types",
+    "langchain_core", "langchain_core.tools", "langchain_core.prompts",
+    "langchain_core.output_parsers", "langchain_core.messages",
+    "langchain_core.runnables", "langchain_core.pydantic_v1",
+    "langchain", "langchain.text_splitter",
+    "pydantic", "tiktoken", "loguru",
+]
+
+for mod_name in _MOCK_MODULES:
+    sys.modules[mod_name] = MagicMock()
+
+# Now safe to import project modules
+import config
+from core.rag_system import _create_llm
+
+
+class TestLLMConfigs:
+    """Test LLM configuration structure."""
+
+    def test_all_providers_have_model(self):
+        for provider, cfg in config.LLM_CONFIGS.items():
+            assert "model" in cfg, f"Provider '{provider}' missing 'model' key"
+
+    def test_all_providers_have_temperature(self):
+        for provider, cfg in config.LLM_CONFIGS.items():
+            assert "temperature" in cfg, f"Provider '{provider}' missing 'temperature' key"
+
+    def test_minimax_config_defaults(self):
+        minimax = config.LLM_CONFIGS["minimax"]
+        assert minimax["model"] == "MiniMax-M2.5"
+        assert minimax["base_url"] == "https://api.minimax.io/v1"
+        assert minimax["temperature"] == 1.0
+
+    def test_ollama_is_default(self):
+        assert config.ACTIVE_LLM_CONFIG == "ollama"
+
+    def test_legacy_config_matches_active(self):
+        active = config.LLM_CONFIGS[config.ACTIVE_LLM_CONFIG]
+        assert config.LLM_MODEL == active["model"]
+        assert config.LLM_TEMPERATURE == active["temperature"]
+
+    def test_minimax_models_available(self):
+        minimax = config.LLM_CONFIGS["minimax"]
+        assert minimax["model"] in ("MiniMax-M2.5", "MiniMax-M2.5-highspeed")
+
+    def test_five_providers_configured(self):
+        expected = {"ollama", "openai", "anthropic", "google", "minimax"}
+        assert set(config.LLM_CONFIGS.keys()) == expected
+
+
+class TestCreateLLM:
+    """Test _create_llm factory function."""
+
+    @patch("core.rag_system.config")
+    def test_ollama_provider(self, mock_config):
+        mock_config.ACTIVE_LLM_CONFIG = "ollama"
+        mock_config.LLM_CONFIGS = {
+            "ollama": {"model": "test-model", "temperature": 0, "url": "http://localhost:11434"}
+        }
+        mock_chat = MagicMock()
+        with patch.dict(sys.modules, {"langchain_ollama": MagicMock(ChatOllama=mock_chat)}):
+            _create_llm()
+            mock_chat.assert_called_once_with(
+                model="test-model", temperature=0, base_url="http://localhost:11434"
+            )
+
+    @patch("core.rag_system.config")
+    def test_minimax_provider(self, mock_config):
+        mock_config.ACTIVE_LLM_CONFIG = "minimax"
+        mock_config.LLM_CONFIGS = {
+            "minimax": {
+                "model": "MiniMax-M2.5",
+                "base_url": "https://api.minimax.io/v1",
+                "temperature": 1.0,
+            }
+        }
+        mock_chat = MagicMock()
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch.dict(sys.modules, {"langchain_openai": MagicMock(ChatOpenAI=mock_chat)}):
+                _create_llm()
+                mock_chat.assert_called_once_with(
+                    model="MiniMax-M2.5",
+                    temperature=1.0,
+                    base_url="https://api.minimax.io/v1",
+                    api_key="test-key",
+                )
+
+    @patch("core.rag_system.config")
+    def test_openai_provider(self, mock_config):
+        mock_config.ACTIVE_LLM_CONFIG = "openai"
+        mock_config.LLM_CONFIGS = {
+            "openai": {"model": "gpt-4o-mini", "temperature": 0}
+        }
+        mock_chat = MagicMock()
+        with patch.dict(sys.modules, {"langchain_openai": MagicMock(ChatOpenAI=mock_chat)}):
+            _create_llm()
+            mock_chat.assert_called_once_with(model="gpt-4o-mini", temperature=0)
+
+    @patch("core.rag_system.config")
+    def test_unsupported_provider_raises(self, mock_config):
+        mock_config.ACTIVE_LLM_CONFIG = "unsupported"
+        mock_config.LLM_CONFIGS = {
+            "unsupported": {"model": "test", "temperature": 0}
+        }
+        with pytest.raises(ValueError, match="Unsupported LLM provider"):
+            _create_llm()
+
+    @patch("core.rag_system.config")
+    def test_minimax_base_url_default(self, mock_config):
+        mock_config.ACTIVE_LLM_CONFIG = "minimax"
+        mock_config.LLM_CONFIGS = {
+            "minimax": {
+                "model": "MiniMax-M2.5",
+                "temperature": 1.0,
+            }
+        }
+        mock_chat = MagicMock()
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+            with patch.dict(sys.modules, {"langchain_openai": MagicMock(ChatOpenAI=mock_chat)}):
+                _create_llm()
+                call_kwargs = mock_chat.call_args[1]
+                assert call_kwargs["base_url"] == "https://api.minimax.io/v1"


### PR DESCRIPTION
## Summary
Add MiniMax as a new LLM provider and implement the multi-provider architecture documented in the README.

MiniMax provides OpenAI-compatible API endpoints, so it integrates seamlessly using `langchain-openai`'s `ChatOpenAI` with a custom `base_url`.

## Supported Models
- `MiniMax-M2.5` - Peak Performance. Ultimate Value. Master the Complex (204K context)
- `MiniMax-M2.5-highspeed` - Same performance, faster and more agile (204K context)

## Changes
- **`project/config.py`**: Add multi-provider `LLM_CONFIGS` dict with MiniMax config (model, base_url, temperature). Keep backward compatibility with `LLM_MODEL` and `LLM_TEMPERATURE`.
- **`project/core/rag_system.py`**: Refactor LLM initialization into `_create_llm()` factory function supporting ollama, openai, anthropic, google, and minimax providers.
- **`requirements.txt`**: Add `langchain-openai` dependency.
- **`README.md`**: Add MiniMax to cloud providers section and provider badge.
- **`project/README.md`**: Add MiniMax to provider reference table, multi-provider config example, and environment variables.
- **`tests/test_llm_provider.py`**: Add 12 unit tests covering config structure, MiniMax defaults, factory function for each provider, and error handling.

## API Documentation
- OpenAI Compatible: https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing
- [x] Unit tests pass (12/12)
- [x] MiniMax API connectivity verified
- [x] Backward compatible - Ollama remains the default provider